### PR TITLE
Fix the physical resource ID in delete response

### DIFF
--- a/src/fixture-handler.ts
+++ b/src/fixture-handler.ts
@@ -11,7 +11,7 @@ export const handler = async (event: CloudFormationCustomResourceEvent, context:
   console.log('Records:', records);
 
   if (event.RequestType === 'Delete') {
-    return { ...event, PhysicalResourceId: context.logStreamName };
+    return event;
   }
 
   const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));


### PR DESCRIPTION
The documentation in https://docs.aws.amazon.com/cdk/api/latest/docs/custom-resources-readme.html says the following about `PhysicalResourceId` in handler response:

> The allocated/assigned physical ID of the resource. If omitted for Create events, the event's RequestId will be used. For Update, the current physical ID will be used. If a different value is returned, CloudFormation will follow with a subsequent Delete for the previous ID (resource replacement). For Delete, it will always return the current physical resource ID, and if the user returns a different one, an error will occur.

This tiny PR changes the handler function to return the physical resource ID from event object in the case of a delete request. Without this change I was getting DELETE_FAILED errors during every stack update.